### PR TITLE
continue repl loop on interrupt, ctrl-D (EOF) still closes repl

### DIFF
--- a/rsql_core/src/shell/repl.rs
+++ b/rsql_core/src/shell/repl.rs
@@ -169,17 +169,7 @@ impl Shell {
 
                     loop_condition
                 }
-                Err(ReadlineError::Interrupted) => {
-                    let mut program_interrupted =
-                        t!("program_interrupted", locale = locale).to_string();
-                    if self.configuration.color {
-                        program_interrupted = program_interrupted.red().to_string();
-                    }
-                    eprintln!("{program_interrupted}");
-                    error!("Program interrupted");
-                    connection.close().await?;
-                    LoopCondition::Exit(1)
-                }
+                Err(ReadlineError::Interrupted) => LoopCondition::Continue,
                 Err(error) => {
                     let mut error_string = t!("error", locale = locale).to_string();
                     let error_message = format!("{error:?}");


### PR DESCRIPTION
## Describe the pull request

Proposing this to resolve a minor pain point I've had while using this tool.

Changes ctrl+c interrupt behavior to clear the current line and repeat the loop instead of closing the repl.

LMK if you think this should be a configuration flag like --sigint-ignore in the mysql/mariadb repls

<!-- If this fixes an issue delete this text and add "fixes #(issue number)" -->
